### PR TITLE
Update authentication method to allow either a vault or manually inputting the Lunchmoney API key

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,13 @@ func main() {
 	}
 
 	flags := getFlags()
-	client, err := lunchmoney.New(ctx, lunchmoney.WithVaultClient(vaultClient))
+
+	var client *lunchmoney.Client
+	if flags.APIKey != "" {
+		client, err = lunchmoney.New(ctx, lunchmoney.WithAPIKey(flags.APIKey))
+	} else {
+		client, err = lunchmoney.New(ctx, lunchmoney.WithVaultClient(vaultClient))
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -79,6 +85,7 @@ func getFlags() models.Flags {
 	flag.StringVar(&flags.AssetID, "assetId", "", "id of the lunchmoney asset account")
 	flag.StringVar(&flags.StartDate, "startDate", today.AddDate(0, 0, -100).Format("2006-01-02"), "start date of the transaction range")
 	flag.StringVar(&flags.EndDate, "endDate", "", "end date of the transaction range")
+	flag.StringVar(&flags.APIKey, "apiKey", "", "Lunchmoney API key")
 
 	flag.Parse()
 

--- a/pkg/lunchmoney/auth.go
+++ b/pkg/lunchmoney/auth.go
@@ -27,6 +27,10 @@ type Secrets struct {
 
 // NewAuthClient creates a new AuthClient with the provided options.
 func NewAuthClient(ctx context.Context, opts Options) (*AuthClient, error) {
+	if opts.apiKey != "" {
+		return NewAuthClientWithAPIKey(ctx, opts.apiKey)
+	}
+
 	authClient := &AuthClient{
 		internalClient: &http.Client{Transport: http.DefaultTransport},
 
@@ -42,6 +46,18 @@ func NewAuthClient(ctx context.Context, opts Options) (*AuthClient, error) {
 	authClient.secrets = *secrets
 
 	authClient.session.SetAPIKey(secrets.apiKey)
+
+	return authClient, nil
+}
+
+// NewAuthClientWithAPIKey creates a new AuthClient with the provided API key.
+func NewAuthClientWithAPIKey(ctx context.Context, apiKey string) (*AuthClient, error) {
+	authClient := &AuthClient{
+		internalClient: &http.Client{Transport: http.DefaultTransport},
+		session:        models.Session{},
+	}
+
+	authClient.session.SetAPIKey(apiKey)
 
 	return authClient, nil
 }

--- a/pkg/lunchmoney/auth_test.go
+++ b/pkg/lunchmoney/auth_test.go
@@ -53,3 +53,13 @@ func TestGetUserData(t *testing.T) {
 	assert.NotNil(t, user)
 	assert.IsType(t, &models.User{}, user)
 }
+
+func TestNewAuthClientWithAPIKey(t *testing.T) {
+	ctx := context.Background()
+	apiKey := "test-api-key"
+
+	authClient, err := NewAuthClientWithAPIKey(ctx, apiKey)
+	assert.NoError(t, err)
+	assert.NotNil(t, authClient)
+	assert.Equal(t, apiKey, authClient.session.GetAPIKey())
+}

--- a/pkg/lunchmoney/option.go
+++ b/pkg/lunchmoney/option.go
@@ -4,6 +4,7 @@ import "github.com/dylanmazurek/go-lunchmoney/pkg/utilities/vault"
 
 type Options struct {
 	vaultClient *vault.Client
+	apiKey      string
 }
 
 func DefaultOptions() Options {
@@ -17,5 +18,11 @@ type Option func(*Options)
 func WithVaultClient(client *vault.Client) Option {
 	return func(opts *Options) {
 		opts.vaultClient = client
+	}
+}
+
+func WithAPIKey(apiKey string) Option {
+	return func(opts *Options) {
+		opts.apiKey = apiKey
 	}
 }


### PR DESCRIPTION
Update the authentication method to allow either a vault to be used or manually inputting the Lunchmoney API key.

* **cmd/main.go**
  - Add a flag to accept the Lunchmoney API key manually.
  - Modify the `main` function to check if the API key is provided via flag.
  - Initialize the Lunchmoney client with the provided API key if available, otherwise use the Vault client.

* **pkg/lunchmoney/auth.go**
  - Add a new function `NewAuthClientWithAPIKey` to create an `AuthClient` with the provided API key.
  - Modify the `NewAuthClient` function to call `NewAuthClientWithAPIKey` if the API key is provided.

* **pkg/lunchmoney/option.go**
  - Add a new option `WithAPIKey` to set the API key in the `Options` struct.
  - Modify the `Options` struct to include an `apiKey` field.

* **pkg/lunchmoney/auth_test.go**
  - Add a new test function `TestNewAuthClientWithAPIKey` to test the `NewAuthClientWithAPIKey` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dylanmazurek/go-lunchmoney/pull/2?shareId=3f104f5c-9721-4542-b587-77e841ce65c5).